### PR TITLE
devex: fix quickstart TTHW + drop static Aurelio bundle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,14 @@ Thanks for considering a contribution. This repo is a FHIR server comparison har
 
 ## Adding a new FHIR server
 
-A new server is an append-only change across four files:
+A new server is an append-only change across six files:
 
 1. **`config/servers.yaml`** — append a new block with `id`, `label`, `base_url`, `version`, `image`, `source_url`, and an `auth` shape (`none`, `basic`, `client_credentials`, or a new type if your server needs one).
 2. **`docker-compose.yml`** — add a service for the server (and any sidecars like a database). Pin the image by sha256 digest — see the header comment for the refresh command.
 3. **`config/queries.yaml`** — add an `expected_<id>` key to every query in the file. Run `python -m fhirbench.compare` to observe real behavior and fill these in.
 4. **`src/fhirbench/conformance/run.py`** — append your server id to `ROSTER`.
+5. **`README.md`** — append a row to the server table at the top so the public roster matches reality.
+6. **`Makefile`** — append your server id to the `SERVERS ?=` default so `make loadtest-ramp-50k` picks it up.
 
 ### Inclusion criteria
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A runnable companion to the blog post [Same FHIR, Different Answers: Comparing 5 FHIR Servers](https://mock.health/blog/fhir-server-compare).
 
-Load one Synthea patient into seven open-source FHIR servers, run the same queries against each, and see which servers agree and which diverge — on your own machine, against your own data. Every server runs locally via `docker compose up`; no paid licenses, no managed services, no cloud accounts.
+Load one Synthea patient into six open-source FHIR servers, run the same queries against each, and see which servers agree and which diverge — on your own machine, against your own data. Every server runs locally via `docker compose up`; no paid licenses, no managed services, no cloud accounts.
 
 | Server | Version | License | Image |
 |--------|---------|---------|-------|
@@ -15,6 +15,14 @@ Load one Synthea patient into seven open-source FHIR servers, run the same queri
 
 Images are pinned by sha256 digest in `docker-compose.yml` so the stack is byte-for-byte reproducible across machines and time.
 
+## Prerequisites
+
+- Docker + Docker Compose v2.
+- Python ≥ 3.11.
+- Java (JDK 11+) and `git` on `$PATH` — Synthea is cloned and built locally on first use to generate the patient bundles.
+- Single-patient matrix (`compare.py`): runs on any laptop. ~8 GB RAM is plenty.
+- Loadtest ramp (`make loadtest-ramp-50k`): expects a beefy host. The loadtest overlay caps each server at 12 CPU / 128 GB RAM with `cpuset: 0-11,16-27`, so the canonical run targets 24 physical cores and ~256 GB RAM. Smaller hosts work for `make loadtest-dryrun`, but published numbers come from the canonical shape.
+
 ## Quickstart
 
 ```bash
@@ -24,7 +32,9 @@ docker compose up -d
 # wait ~60s for all services to come up
 
 pip install -e .
-python -m fhirbench.load_bundle --server hapi
+python -m fhirbench.load_bundle --server hapi      # first call clones+builds
+                                                   # Synthea (~45s) and generates
+                                                   # one deterministic patient
 python -m fhirbench.load_bundle --server aidbox
 python -m fhirbench.load_bundle --server medplum
 python -m fhirbench.load_bundle --server msfhir
@@ -32,6 +42,8 @@ python -m fhirbench.load_bundle --server blaze
 python -m fhirbench.load_bundle --server spark
 python -m fhirbench.compare
 ```
+
+The first `load_bundle` call generates the patient bundle on demand: Synthea is cloned + built into `./synthea/`, run with seed 42 against Massachusetts/Boston, and the resulting bundle lands in `data/loadtest/fhir/` (along with `data/loadtest/prerequisites/` for the practitioner + hospital references). Every subsequent `load_bundle` reuses the same files, so all six servers ingest byte-identical bundles. Synthea needs Java and `git` on `$PATH`; pass `--bundle path.json` to use your own.
 
 `fhirbench.compare` probes every server in `config/servers.yaml` and only includes the ones that respond. Servers that aren't up or aren't reachable are skipped with a one-line log — no flags needed to opt out.
 
@@ -44,7 +56,7 @@ python -m fhirbench.load_bundle --server hapi
 python -m fhirbench.compare
 ```
 
-The matrix shows one column (HAPI) and the verdict column documents the expected behavior for the other six servers.
+The matrix shows one column (HAPI) and the verdict column documents the expected behavior for the other five servers.
 
 ## What the matrix demonstrates
 
@@ -96,7 +108,7 @@ Per-query p50/p95/p99 is preserved in `evidence[].per_verb[]` in the round artif
 A parallel TestScript-based matrix checks each server against a collection of FHIR R4 base, SMART-on-FHIR, and Bulk Data v2 conformance profiles. Each cell is pass / fail / skipped with a spec citation.
 
 ```bash
-make conformance-run       # execute TestScripts against all 7 servers
+make conformance-run       # execute TestScripts against all 6 servers
 make conformance-parse     # fold into results/rounds/<id>/conformance.json
 make conformance-validate  # schema-check the round artifact
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,5 +14,5 @@ For vulnerabilities in the FHIR servers themselves, report upstream to the respe
 
 ## What this repo is and is not
 
-- **Is:** a reproducible comparison harness that stands up 7 OSS FHIR servers locally and runs the same test suite against each.
+- **Is:** a reproducible comparison harness that stands up 6 OSS FHIR servers locally and runs the same test suite against each.
 - **Is not:** a production deployment guide, a certified certification suite, or a security audit tool.

--- a/docs/conformance-methodology.md
+++ b/docs/conformance-methodology.md
@@ -21,7 +21,7 @@ Profiles deliberately scoped to a **kickoff** subset carry that word in the colu
 
 ### Why SMART is not a column in v0.3
 
-The SMART discovery profile was scored in v0.1–v0.2 but dropped from the v0.3 matrix. Reason: three of the seven roster servers (HAPI, MS FHIR, Blaze) do not ship SMART discovery in their default Docker image. Their failures reflect **compose configuration choices** (no OAuth provider bolted on, security disabled for loadtest parity), not intrinsic server behavior. A column where half the reds measure our ops setup rather than the vendor's code was misleading readers, so I retired it.
+The SMART discovery profile was scored in v0.1–v0.2 but dropped from the v0.3 matrix. Reason: three of the six roster servers (HAPI, MS FHIR, Blaze) do not ship SMART discovery in their default Docker image. Their failures reflect **compose configuration choices** (no OAuth provider bolted on, security disabled for loadtest parity), not intrinsic server behavior. A column where half the reds measure our ops setup rather than the vendor's code was misleading readers, so I retired it.
 
 The TestScripts and profile spec are preserved under `conformance/{profiles,testscripts}/_archived/smart-on-fhir-v2/` for revival in Round 1 when I pair each server with the vendor-recommended OAuth layer (Keycloak/smart-launcher for HAPI, Azure AD for MS FHIR, etc.) and can produce a fair apples-to-apples comparison.
 
@@ -112,7 +112,7 @@ cp .env.example .env       # fill in AIDBOX_LICENSE (free) and MEDPLUM_CLIENT_*
 # Bring up servers WITH conformance feature flags enabled:
 docker compose -f docker-compose.yml -f docker-compose.conformance-features.yml up -d
 
-# Run the conformance sIep against all 7 (smoke-checks /metadata before each profile):
+# Run the conformance step against all 6 (smoke-checks /metadata before each profile):
 make conformance CONF_ROUND=2026-q2-r000
 
 # Inspect the matrix (all 3 profiles):

--- a/src/fhirbench/compare.py
+++ b/src/fhirbench/compare.py
@@ -228,9 +228,22 @@ def render_table(
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--queries", default=str(DEFAULT_QUERIES))
-    parser.add_argument("--servers", default=str(DEFAULT_SERVERS))
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--queries",
+        default=str(DEFAULT_QUERIES),
+        help="Path to queries.yaml (default: config/queries.yaml)",
+    )
+    parser.add_argument(
+        "--servers-file",
+        "--servers",
+        dest="servers_file",
+        default=str(DEFAULT_SERVERS),
+        help="Path to servers.yaml (default: config/servers.yaml)",
+    )
     parser.add_argument(
         "--only",
         help="Comma-separated server ids to include (default: all in servers.yaml)",
@@ -238,7 +251,7 @@ def main() -> int:
     args = parser.parse_args()
 
     queries_path = Path(args.queries)
-    servers_path = Path(args.servers)
+    servers_path = Path(args.servers_file)
     for p, kind in [(queries_path, "queries"), (servers_path, "servers")]:
         if not p.exists():
             print(f"ERROR: {kind} file not found: {p}", file=sys.stderr)
@@ -249,6 +262,15 @@ def main() -> int:
 
     if args.only:
         allow = {s.strip() for s in args.only.split(",") if s.strip()}
+        known = {s.get("id") for s in servers_cfg}
+        unknown = allow - known
+        if unknown:
+            print(
+                f"ERROR: --only contains unknown server id(s): {', '.join(sorted(unknown))}",
+                file=sys.stderr,
+            )
+            print(f"  Valid ids: {', '.join(sorted(i for i in known if i))}", file=sys.stderr)
+            return 2
         servers_cfg = [s for s in servers_cfg if s.get("id") in allow]
 
     print("Probing servers:")

--- a/src/fhirbench/harness/ramp.py
+++ b/src/fhirbench/harness/ramp.py
@@ -494,11 +494,23 @@ def run_ramp(
 
 
 def parse_checkpoints(spec: str) -> tuple[int, ...]:
-    return tuple(int(x.strip()) for x in spec.split(",") if x.strip())
+    parts = [x.strip() for x in spec.split(",") if x.strip()]
+    out = []
+    for p in parts:
+        try:
+            out.append(int(p))
+        except ValueError:
+            raise SystemExit(
+                f"ERROR: --checkpoints must be comma-separated integers, got '{p}'"
+            )
+    return tuple(out)
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description=__doc__)
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     ap.add_argument("--run-id", required=True)
     ap.add_argument("--checkpoints", required=True,
                     help="Comma-separated patient counts. Each checkpoint is run cold against every server.")

--- a/src/fhirbench/load_bundle.py
+++ b/src/fhirbench/load_bundle.py
@@ -1,29 +1,40 @@
 #!/usr/bin/env python3
-"""POST data/Aurelio_Whorton_transaction.json to a FHIR server.
+"""POST one Synthea patient transaction Bundle to a FHIR server.
 
 Usage:
     docker compose up -d                         # or run a single server
-    pip install -r requirements.txt
-    python load_bundle.py --server hapi          # defaults to hapi
-    python load_bundle.py --server aidbox
-    python load_bundle.py --server medplum
-    python load_bundle.py --server msfhir
-    python load_bundle.py --server blaze
-    python load_bundle.py --server spark
+    pip install -e .
+    python -m fhirbench.load_bundle --server hapi          # defaults to hapi
+    python -m fhirbench.load_bundle --server aidbox
+    python -m fhirbench.load_bundle --server medplum
+    python -m fhirbench.load_bundle --server msfhir
+    python -m fhirbench.load_bundle --server blaze
+    python -m fhirbench.load_bundle --server spark
 
-Loads one Synthea patient (Aurelio Whorton, 171 resources) as a single
-FHIR transaction bundle. The bundle's internal `urn:uuid:` references are
-resolved automatically by FHIR transaction semantics — no client-side
-rewriting required.
+If `data/loadtest/fhir/` is empty on first run, this auto-invokes
+`fhirbench.harness.generate --count 1` to clone+build Synthea and produce
+one deterministic patient (seed=42, Massachusetts/Boston). The first
+patient bundle, sorted alphabetically, is the one POSTed; with the fixed
+seed, every fresh clone gets the same patient. Pass `--bundle path.json`
+to override.
 
-Each server gets the same bundle. Servers diverge on validation strictness:
-Aidbox applies its own profile, Medplum is HAPI-permissive, MS FHIR is
-mid-strict. Raw responses are printed so you can audit the divergence.
+Prerequisites first: Synthea patient bundles use conditional references
+to `Practitioner?identifier=...` and `Organization?identifier=...`. Those
+references 404 unless the matching `practitionerInformation*.json` and
+`hospitalInformation*.json` bundles have been ingested first. We POST
+prerequisites in alphabetical order, then the patient bundle.
+
+Each server gets the same bundles. Servers diverge on validation
+strictness: Aidbox applies its own profile, Medplum is HAPI-permissive,
+MS FHIR is mid-strict. Raw responses are printed so you can audit the
+divergence.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
+import subprocess
 import sys
 from collections import Counter
 from pathlib import Path
@@ -33,71 +44,183 @@ import httpx
 from fhirbench.servers import build_headers, find_server, load_servers, resolve_base_url
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-BUNDLE_PATH = REPO_ROOT / "data" / "Aurelio_Whorton_transaction.json"
 DEFAULT_SERVERS = REPO_ROOT / "config" / "servers.yaml"
+DEFAULT_FHIR_DIR = REPO_ROOT / "data" / "loadtest" / "fhir"
+DEFAULT_PREREQ_DIR = REPO_ROOT / "data" / "loadtest" / "prerequisites"
+ENV_FILE = REPO_ROOT / ".env"
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--server", default="hapi", help="Server id from servers.yaml (default: hapi)")
-    parser.add_argument("--servers-file", default=str(DEFAULT_SERVERS))
-    parser.add_argument("--bundle", default=str(BUNDLE_PATH))
-    args = parser.parse_args()
+def _reload_env_file(path: Path) -> None:
+    if not path.exists():
+        return
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        k = k.strip()
+        v = v.strip().strip('"').strip("'")
+        if k:
+            os.environ[k] = v
 
-    bundle_path = Path(args.bundle)
-    if not bundle_path.exists():
-        print(f"ERROR: bundle not found: {bundle_path}", file=sys.stderr)
-        return 2
 
-    bundle = json.loads(bundle_path.read_text())
+def _maybe_bootstrap_medplum(server: dict, servers_file: Path) -> dict:
+    """If Medplum auth creds are blank, run bootstrap_medplum and reload config.
+
+    bootstrap_medplum is idempotent: it probes /oauth2/token first and exits
+    quickly if existing creds work. Triggering it on blank creds means a
+    fresh-clone user following README quickstart against `--server medplum`
+    no longer hits a 401 on an unprovisioned ClientApplication.
+    """
+    if server.get("id") != "medplum":
+        return server
+    auth = server.get("auth") or {}
+    if auth.get("client_id") and auth.get("client_secret"):
+        return server
+    print("Medplum credentials blank in .env; running bootstrap_medplum ...", file=sys.stderr)
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "fhirbench.harness.bootstrap_medplum"],
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: bootstrap_medplum failed (exit {exc.returncode})", file=sys.stderr)
+        print("  Is Medplum running? Try: docker compose ps medplum", file=sys.stderr)
+        sys.exit(1)
+    _reload_env_file(ENV_FILE)
+    return find_server(load_servers(servers_file), "medplum")
+
+
+def _resolve_patient_bundle(explicit: str | None) -> Path:
+    """Pick the bundle to POST.
+
+    Precedence: --bundle wins. Otherwise the first patient bundle in
+    data/loadtest/fhir/, alphabetical. If that directory is empty, run
+    `fhirbench.harness.generate --count 1` first; with the default seed=42
+    Synthea is deterministic, so every fresh clone gets the same patient.
+    """
+    if explicit:
+        p = Path(explicit)
+        if not p.exists():
+            print(f"ERROR: --bundle file not found: {p}", file=sys.stderr)
+            sys.exit(2)
+        return p
+
+    bundles = sorted(DEFAULT_FHIR_DIR.glob("*.json")) if DEFAULT_FHIR_DIR.exists() else []
+    if not bundles:
+        print(
+            f"No patient bundles in {DEFAULT_FHIR_DIR.relative_to(REPO_ROOT)}; "
+            "running fhirbench.harness.generate --count 1 ...",
+            file=sys.stderr,
+        )
+        try:
+            subprocess.run(
+                [sys.executable, "-m", "fhirbench.harness.generate", "--count", "1"],
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            print(f"ERROR: generate failed (exit {exc.returncode})", file=sys.stderr)
+            print(
+                "  Synthea needs Java + git on PATH. See "
+                "src/fhirbench/harness/generate.py for the build details.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        bundles = sorted(DEFAULT_FHIR_DIR.glob("*.json"))
+    if not bundles:
+        print(f"ERROR: still no bundles in {DEFAULT_FHIR_DIR} after generate", file=sys.stderr)
+        sys.exit(1)
+    return bundles[0]
+
+
+def _post_bundle(client: httpx.Client, server: dict, base_url: str, path: Path) -> int:
+    """POST one transaction Bundle. Returns failure count among the entries."""
+    bundle = json.loads(path.read_text())
     if bundle.get("type") != "transaction":
-        print(f"ERROR: bundle type is '{bundle.get('type')}', expected 'transaction'", file=sys.stderr)
-        return 2
-
-    servers = load_servers(Path(args.servers_file))
-    server = find_server(servers, args.server)
-    base_url = resolve_base_url(server)
-    if not base_url:
-        print(f"ERROR: server '{args.server}' has no base_url configured", file=sys.stderr)
-        return 2
+        print(f"ERROR: {path.name}: bundle type is '{bundle.get('type')}', expected 'transaction'",
+              file=sys.stderr)
+        return 1
 
     entry_count = len(bundle.get("entry") or [])
-    print(f"Loading {entry_count} entries to {server.get('label', args.server)} at {base_url} ...")
-
+    print(f"  POST {path.name} ({entry_count} entries) ...")
     try:
-        with httpx.Client(timeout=120.0) as client:
-            headers = build_headers(server, client)
-            resp = client.post(base_url, json=bundle, headers=headers)
+        headers = build_headers(server, client)
+        resp = client.post(base_url, json=bundle, headers=headers)
     except httpx.RequestError as exc:
         print(f"ERROR: HTTP request failed: {exc}", file=sys.stderr)
-        print(f"  Is {args.server} running? Try: curl -sf {base_url}/metadata > /dev/null && echo OK", file=sys.stderr)
-        return 1
+        print(f"  Is the server running? Try: curl -sf {base_url}/metadata > /dev/null && echo OK",
+              file=sys.stderr)
+        return entry_count or 1
 
     if not (200 <= resp.status_code < 300):
-        print(f"ERROR: {args.server} returned HTTP {resp.status_code}", file=sys.stderr)
+        print(f"ERROR: server returned HTTP {resp.status_code}", file=sys.stderr)
         print(resp.text[:1500], file=sys.stderr)
-        return 1
+        return entry_count or 1
 
     try:
         result = resp.json()
     except Exception:
         print("ERROR: response was not valid JSON", file=sys.stderr)
         print(resp.text[:500], file=sys.stderr)
-        return 1
+        return entry_count or 1
 
     statuses: Counter[str] = Counter()
     for e in result.get("entry") or []:
         status = (e.get("response") or {}).get("status", "missing")
         statuses[status.split()[0]] += 1
-
     summary = ", ".join(f"{n} × {s}" for s, n in sorted(statuses.items()))
-    print(f"Loaded {entry_count} entries ({summary})")
+    print(f"    {entry_count} entries ({summary})")
+    return sum(n for s, n in statuses.items() if not s.startswith("2"))
 
-    failures = sum(n for s, n in statuses.items() if not s.startswith("2"))
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--server", default="hapi", help="Server id from servers.yaml (default: hapi)")
+    parser.add_argument("--servers-file", default=str(DEFAULT_SERVERS),
+                        help="Path to servers.yaml (default: config/servers.yaml)")
+    parser.add_argument("--bundle", default=None,
+                        help="Path to a specific transaction Bundle JSON. "
+                             "Default: first bundle in data/loadtest/fhir/, generated on first run.")
+    parser.add_argument("--prereq-dir", default=str(DEFAULT_PREREQ_DIR),
+                        help="Directory of practitioner/hospital prerequisite bundles "
+                             "to POST first (default: data/loadtest/prerequisites/)")
+    parser.add_argument("--skip-prereqs", action="store_true",
+                        help="Skip the prerequisite bundles. Patient bundles will fail to "
+                             "resolve Practitioner/Organization conditional references unless "
+                             "the server already has them.")
+    args = parser.parse_args()
+
+    bundle_path = _resolve_patient_bundle(args.bundle)
+
+    servers = load_servers(Path(args.servers_file))
+    server = find_server(servers, args.server)
+    server = _maybe_bootstrap_medplum(server, Path(args.servers_file))
+    base_url = resolve_base_url(server)
+    if not base_url:
+        print(f"ERROR: server '{args.server}' has no base_url configured", file=sys.stderr)
+        return 2
+
+    label = server.get("label", args.server)
+    print(f"Loading to {label} at {base_url}")
+
+    failures = 0
+    with httpx.Client(timeout=120.0) as client:
+        if not args.skip_prereqs:
+            prereq_dir = Path(args.prereq_dir)
+            prereqs = sorted(prereq_dir.glob("*.json")) if prereq_dir.exists() else []
+            if prereqs:
+                print(f"Prerequisites: {len(prereqs)} bundle(s) from {prereq_dir.relative_to(REPO_ROOT)}")
+                for p in prereqs:
+                    failures += _post_bundle(client, server, base_url, p)
+        print(f"Patient bundle: {bundle_path.relative_to(REPO_ROOT)}")
+        failures += _post_bundle(client, server, base_url, bundle_path)
+
     if failures:
         print(f"\n{failures} entries did not return 2xx — see server logs", file=sys.stderr)
         return 1
-
     return 0
 
 


### PR DESCRIPTION
- load_bundle.py: drop hardcoded data/Aurelio_Whorton_transaction.json. Auto-resolve to the alphabetical-first patient bundle in data/loadtest/fhir/, running fhirbench.harness.generate --count 1 on first use. Synthea's seed=42/Massachusetts/Boston is deterministic, so every fresh clone gets the same patient. Also POSTs prereq bundles (practitioners + hospitals) before the patient so conditional references resolve.
- load_bundle.py: auto-invoke bootstrap_medplum when --server medplum has blank creds in .env (idempotent; reloads .env after).
- compare.py / load_bundle.py / ramp.py: RawDescriptionHelpFormatter so multi-paragraph --help renders with line breaks.
- compare.py: validate --only ids against servers.yaml; rename --servers to --servers-file (alias kept) so it stops colliding with --only.
- ramp.py: friendly error on bad --checkpoints instead of stack trace.
- Server-count drift swept (5/6/7 -> 6) across README, SECURITY, docs/conformance-methodology.
- README: prerequisites section (Java/git for Synthea, hardware caveats).
- CONTRIBUTING: add-a-server checklist now covers README + Makefile too.